### PR TITLE
Fix #27 Add set/get methods for data bounding

### DIFF
--- a/src/main/java/net/praqma/tracey/broker/impl/filters/PayloadJSONFilter.java
+++ b/src/main/java/net/praqma/tracey/broker/impl/filters/PayloadJSONFilter.java
@@ -15,6 +15,9 @@ import java.util.logging.Logger;
 public class PayloadJSONFilter implements TraceyFilter {
 
     private String pattern = "";
+    private String key = "";
+    private String value = "";
+
     private static final Logger LOG = Logger.getLogger(PayloadJSONFilter.class.getName());
 
 
@@ -24,6 +27,8 @@ public class PayloadJSONFilter implements TraceyFilter {
     }
 
     public PayloadJSONFilter(String key, String value){
+        this.key = key;
+        this.value = value;
         this.pattern = String.format("$..*[?(@.%s == \"%s\")]", key, value);
     }
 
@@ -45,4 +50,29 @@ public class PayloadJSONFilter implements TraceyFilter {
         }
         return null;
     }
+
+    public String getPattern() {
+        return pattern;
+    }
+
+    public void setPattern(final String pattern) {
+        this.pattern = pattern;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(final String key) {
+        this.key = key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(final String value) {
+        this.value = value;
+    }
+
 }


### PR DESCRIPTION
Fixes:
- Save data from Tracey plugin fields (add set/get methods to JSON filter class for data bounding)
- Fix null pointer exception. In some cases, it was allowed to set a null to TraceyFilter object. Changed the filters field to final and created a new method to check if the object is null then return a Collections.emptyList() object. 
